### PR TITLE
Fix update script

### DIFF
--- a/.github/workflows/update-printers.yml
+++ b/.github/workflows/update-printers.yml
@@ -37,7 +37,7 @@ jobs:
         git config --global user.email "github-actions@github.com"
 
         # Get list of changed files (comma-separated)
-        CHANGED_FILES=$(git diff --name-only | tr '\n' ', ' | sed 's/, $//')
+        CHANGED_FILES="$(git diff --name-only | paste -sd "," -)"
 
         git add -A
         git diff --cached --exit-code || (


### PR DESCRIPTION
This pull fixes the update script by replacing the `tr` and `sed` combo with `paste` and adding commas for safety.