### PR TITLE
Add support for relative image URLs in the journal files (also add my own printer to the list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.venv
 restored_files

--- a/doc_update_script/config.yaml
+++ b/doc_update_script/config.yaml
@@ -1,5 +1,12 @@
 ## Add your printers below
 
+Ender X4: 
+  title: "Ender X4"
+  description: "A low cost, quad extruder 3D printer based on the Ender 3."
+  repository: "https://github.com/ading2210/ender-x4/raw/refs/heads/main/journal.md"
+  file_name: "ender_x4.md"
+  rewrite_urls: Yes
+
 Infinite Benchy Theorem:
   title: "Infinite Benchy Theorem"
   description: "A belted, enclosed 3D printer designed for 24/7 3D printing"
@@ -354,6 +361,7 @@ Billig:
   description: "Sub 300$ 400²x250mm CoreXY enclosed 3D printer"
   repository: "https://raw.githubusercontent.com/playlogo/billig/refs/heads/main/JOURNAL.md"
   file_name: billig.md
+  rewrite_urls: Yes
 
 WayneTech3D:
   title: "WayneTech3D"

--- a/doc_update_script/copy-printer-files.py
+++ b/doc_update_script/copy-printer-files.py
@@ -1,6 +1,9 @@
 import os
 import yaml
 import requests
+import re
+import sys
+from urllib.parse import urlparse
 
 # Directories
 script_dir = os.path.dirname(os.path.realpath(__file__))
@@ -10,8 +13,31 @@ website_dir = os.path.join(script_dir, '../website/src/content/docs/printers')
 # Make sure the website directory exists
 os.makedirs(website_dir, exist_ok=True)
 
+#rewrite relative image paths to reference the github cdn instead
+#this implementation is somewhat hacky with using regex to parse markdown
+def rewrite_image_urls(text, url):
+    #parse the url and find the base path
+    url_obj = urlparse(url)
+    base_url = f"{url_obj.scheme}://{url_obj.netloc}"
+    base_path = os.path.dirname(url_obj.path)
+
+    def regex_callback(match):
+        img_url = match.group(1) or match.group(2)
+        img_url_obj = urlparse(img_url)
+        #if this is already an absolute url, just return the original match
+        if img_url_obj.netloc:
+            return match.group(0)
+        #otherwise join the path of the image to the base path and return it
+        new_path = os.path.join(base_path, img_url_obj.path)
+        new_url = base_url + new_path
+        return match.group(0).replace(img_url, new_url, 1)
+
+    #this regex matches the urls inside markdown images and html image tags
+    urls_regex = r"!\[.+?]\((.+?)\)|<img.+?src=['\"](.+?)['\"].*?>"
+    return re.sub(urls_regex, regex_callback, text)
+
 # Function to download a markdown file and create metadata within the file
-def download_and_create_metadata(url, title, description, project_name, file_name):
+def download_and_create_metadata(url, title, description, project_name, file_name, rewrite_urls):
     # If file_name is provided in the config, use it; otherwise, use the basename of the URL
     if file_name:
         filename = file_name
@@ -32,11 +58,14 @@ project_name: "{project_name}"
 repository: "{url}"
 ---
 """
+        text = metadata + response.text
+
+        if rewrite_urls:
+            text = rewrite_image_urls(text, url)
 
         # Write metadata + markdown content to the file
-        with open(file_path, 'wb') as f:
-            f.write(metadata.encode('utf-8'))  # Write metadata first
-            f.write(response.content)  # Then write the markdown content
+        with open(file_path, "w") as f:
+            f.write(text)
         print(f"Downloaded {filename} to {file_path} with metadata")
 
     else:
@@ -53,12 +82,13 @@ def parse_config(config_file):
         description = project_info.get('description')
         repository = project_info.get('repository')
         file_name = project_info.get('file_name', None)  # Default to None if not provided
+        rewrite_urls = project_info.get('rewrite_urls', False) 
 
         if not file_name.endswith('.md'):
             print(f"Skipping project {project_name} due to invalid file name")
             continue
         if title and description and repository:
-            download_and_create_metadata(repository, title, description, project_name, file_name)
+            download_and_create_metadata(repository, title, description, project_name, file_name, rewrite_urls)
         else:
             print(f"Skipping project {project_name} due to missing required fields")
 

--- a/website/src/content/docs/overview/faq.md
+++ b/website/src/content/docs/overview/faq.md
@@ -23,7 +23,7 @@ Written updates! Here's what to do:
 - Get the URL to that file. Edit the [config.yaml file](https://github.com/hackclub/infill/blob/main/doc_update_script/config.yaml) of this website to add your printer to the list!
 - Within 30 minutes, your journal will automagically be added to the website! Automation by yours truly.
 
-Reminder to NOT reference static assets in your markdown file. Please use #cdn in the slack and paste links there instead! Otherwise the entire verce deployment will break and I'll have to hunt you down :peefest:
+Tip: You can reference static assets in your markdown file, using a relative URL (such as `![My image](images/picture.png)`). Make sure you add `rewrite_urls: Yes` to the config entry for your printer in this repository. This will load the files from the Github CDN. 
 
 #### Do I *need* to have written updates on the website?
 Yup! This is for a couple reasons:


### PR DESCRIPTION
I'm making this PR so that I can avoid putting a bunch of absolute URLs in my source files. By keeping relative URLs in the source markdown files, everyone's journals can be a bit cleaner. 

This PR does not change any existing behavior. Rewriting URLs is enabled by a config option in the YAML, set per entry. 

I have tested this to work locally. 

![image](https://github.com/user-attachments/assets/510086b4-3dff-4f04-a82c-58f47853e231)
