### PR TITLE
Enable URL rewriting for all printer files

### DIFF
--- a/doc_update_script/config.yaml
+++ b/doc_update_script/config.yaml
@@ -5,7 +5,6 @@ Ender X4:
   description: "A low cost, quad extruder 3D printer based on the Ender 3."
   repository: "https://github.com/ading2210/ender-x4/raw/refs/heads/main/journal.md"
   file_name: "ender_x4.md"
-  rewrite_urls: Yes
 
 Infinite Benchy Theorem:
   title: "Infinite Benchy Theorem"
@@ -361,7 +360,6 @@ Billig:
   description: "Sub 300$ 400²x250mm CoreXY enclosed 3D printer"
   repository: "https://raw.githubusercontent.com/playlogo/billig/refs/heads/main/JOURNAL.md"
   file_name: billig.md
-  rewrite_urls: Yes
 
 WayneTech3D:
   title: "WayneTech3D"

--- a/doc_update_script/copy-printer-files.py
+++ b/doc_update_script/copy-printer-files.py
@@ -33,11 +33,11 @@ def rewrite_image_urls(text, url):
         return match.group(0).replace(img_url, new_url, 1)
 
     #this regex matches the urls inside markdown images and html image tags
-    urls_regex = r"!\[.+?]\((.+?)\)|<img.+?src=['\"](.+?)['\"].*?>"
+    urls_regex = r"!\[.+?]\(<?(.+?)>?\)|<img.+?src=['\"](.+?)['\"].*?>"
     return re.sub(urls_regex, regex_callback, text)
 
 # Function to download a markdown file and create metadata within the file
-def download_and_create_metadata(url, title, description, project_name, file_name, rewrite_urls):
+def download_and_create_metadata(url, title, description, project_name, file_name):
     # If file_name is provided in the config, use it; otherwise, use the basename of the URL
     if file_name:
         filename = file_name
@@ -59,9 +59,7 @@ repository: "{url}"
 ---
 """
         text = metadata + response.text
-
-        if rewrite_urls:
-            text = rewrite_image_urls(text, url)
+        text = rewrite_image_urls(text, url)
 
         # Write metadata + markdown content to the file
         with open(file_path, "w") as f:
@@ -82,13 +80,12 @@ def parse_config(config_file):
         description = project_info.get('description')
         repository = project_info.get('repository')
         file_name = project_info.get('file_name', None)  # Default to None if not provided
-        rewrite_urls = project_info.get('rewrite_urls', False) 
 
         if not file_name.endswith('.md'):
             print(f"Skipping project {project_name} due to invalid file name")
             continue
         if title and description and repository:
-            download_and_create_metadata(repository, title, description, project_name, file_name, rewrite_urls)
+            download_and_create_metadata(repository, title, description, project_name, file_name)
         else:
             print(f"Skipping project {project_name} due to missing required fields")
 

--- a/website/src/content/docs/overview/faq.md
+++ b/website/src/content/docs/overview/faq.md
@@ -23,7 +23,7 @@ Written updates! Here's what to do:
 - Get the URL to that file. Edit the [config.yaml file](https://github.com/hackclub/infill/blob/main/doc_update_script/config.yaml) of this website to add your printer to the list!
 - Within 30 minutes, your journal will automagically be added to the website! Automation by yours truly.
 
-Tip: You can reference static assets in your markdown file, using a relative URL (such as `![My image](images/picture.png)`). Make sure you add `rewrite_urls: Yes` to the config entry for your printer in this repository. This will load the files from the Github CDN. 
+Tip: You can reference static assets in your markdown file, using a relative URL (such as `![My image](images/picture.png)`). This will load the image from the Github CDN.
 
 #### Do I *need* to have written updates on the website?
 Yup! This is for a couple reasons:


### PR DESCRIPTION
I originally made the URL rewriting feature opt-in, but I did more testing and I believe it can be safely enabled for all printer files.

This should prevent the build from randomly breaking if a single person updates their journal to include a relative URL.

![image](https://github.com/user-attachments/assets/360a060a-6a4f-4b61-9799-0b3a3e694153)
