### PR TITLE
Fix printer regex

### DIFF
--- a/doc_update_script/copy-printer-files.py
+++ b/doc_update_script/copy-printer-files.py
@@ -33,7 +33,7 @@ def rewrite_image_urls(text, url):
         return match.group(0).replace(img_url, new_url, 1)
 
     #this regex matches the urls inside markdown images and html image tags
-    urls_regex = r"!\[.+?]\(<?(.+?)>?\)|<img.+?src=['\"](.+?)['\"].*?>"
+    urls_regex = r"!\[.*?]\(<?(.+?)>?\)|<img.+?src=['\"](.+?)['\"].*?>"
     return re.sub(urls_regex, regex_callback, text)
 
 # Function to download a markdown file and create metadata within the file


### PR DESCRIPTION
The previous regex didn't catch Markdown images without alt text. So `![](myimage.png)` would not get rewritten and that would cause the deployment to break. 

For example:

![image](https://github.com/user-attachments/assets/de2d8db4-2f5f-4a09-b48e-2bec611c9576)